### PR TITLE
Fix Header and JornadaSection responsive layout issues

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -61,32 +61,29 @@ const Header = () => {
                 </Link>
               ))}
             </nav>
+          </div>
 
           {/* Right Side: Search and Contact */}
           <div className="hidden md:flex items-center space-x-3 lg:space-x-4 xl:space-x-6">
-
-          </div>
-
-          {/* Search Input with Figma Design - Responsive widths */}
-          <div className="relative">
-            <form onSubmit={handleSearch} className="relative">
-              <div className="flex items-center w-[160px] lg:w-[190px] xl:w-[220px] 2xl:w-[240px] h-[50px] bg-[#03120C] rounded-[32px] shadow-[0_4px_12px_rgba(13,10,44,0.06)]">
-                <div className="flex-1 px-3 lg:px-4">
-                  <input
-                    type="text"
-                    placeholder="Procurar..."
-                    value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
-                    className="w-full bg-transparent text-[#B8C1BF] placeholder-[#B8C1BF] text-base lg:text-lg font-normal outline-none border-none"
-                  />
+            {/* Search Input with Figma Design - Responsive widths */}
+            <div className="relative">
+              <form onSubmit={handleSearch} className="relative">
+                <div className="flex items-center w-[160px] lg:w-[190px] xl:w-[220px] 2xl:w-[240px] h-[50px] bg-[#03120C] rounded-[32px] shadow-[0_4px_12px_rgba(13,10,44,0.06)]">
+                  <div className="flex-1 px-3 lg:px-4">
+                    <input
+                      type="text"
+                      placeholder="Procurar..."
+                      value={searchQuery}
+                      onChange={(e) => setSearchQuery(e.target.value)}
+                      className="w-full bg-transparent text-[#B8C1BF] placeholder-[#B8C1BF] text-base lg:text-lg font-normal outline-none border-none"
+                    />
+                  </div>
+                  <div className="flex items-center justify-center p-[10px]">
+                    <Search className="w-5 h-5 lg:w-6 lg:h-6 text-[#B8C1BF]" />
+                  </div>
                 </div>
-                <div className="flex items-center justify-center p-[10px]">
-                  <Search className="w-5 h-5 lg:w-6 lg:h-6 text-[#B8C1BF]" />
-                </div>
-              </div>
-            </form>
-          </div>
-
+              </form>
+            </div>
 
             <Link to="contact-form" smooth={true} duration={500}>
               <Button

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -61,6 +61,10 @@ const Header = () => {
                 </Link>
               ))}
             </nav>
+
+          {/* Right Side: Search and Contact */}
+          <div className="hidden md:flex items-center space-x-3 lg:space-x-4 xl:space-x-6">
+
           </div>
 
           {/* Search Input with Figma Design - Responsive widths */}
@@ -82,9 +86,6 @@ const Header = () => {
               </div>
             </form>
           </div>
-
-          {/* Right Side: Search and Contact */}
-          <div className="hidden md:flex items-center space-x-3 lg:space-x-4 xl:space-x-6">
 
 
             <Link to="contact-form" smooth={true} duration={500}>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -63,27 +63,29 @@ const Header = () => {
             </nav>
           </div>
 
+          {/* Search Input with Figma Design - Responsive widths */}
+          <div className="relative">
+            <form onSubmit={handleSearch} className="relative">
+              <div className="flex items-center w-[160px] lg:w-[190px] xl:w-[220px] 2xl:w-[240px] h-[50px] bg-[#03120C] rounded-[32px] shadow-[0_4px_12px_rgba(13,10,44,0.06)]">
+                <div className="flex-1 px-3 lg:px-4">
+                  <input
+                    type="text"
+                    placeholder="Procurar..."
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    className="w-full bg-transparent text-[#B8C1BF] placeholder-[#B8C1BF] text-base lg:text-lg font-normal outline-none border-none"
+                  />
+                </div>
+                <div className="flex items-center justify-center p-[10px]">
+                  <Search className="w-5 h-5 lg:w-6 lg:h-6 text-[#B8C1BF]" />
+                </div>
+              </div>
+            </form>
+          </div>
+
           {/* Right Side: Search and Contact */}
           <div className="hidden md:flex items-center space-x-3 lg:space-x-4 xl:space-x-6">
-            {/* Search Input with Figma Design - Responsive widths */}
-            <div className="relative">
-              <form onSubmit={handleSearch} className="relative">
-                <div className="flex items-center w-[160px] lg:w-[190px] xl:w-[220px] 2xl:w-[240px] h-[50px] bg-[#03120C] rounded-[32px] shadow-[0_4px_12px_rgba(13,10,44,0.06)]">
-                  <div className="flex-1 px-3 lg:px-4">
-                    <input
-                      type="text"
-                      placeholder="Procurar..."
-                      value={searchQuery}
-                      onChange={(e) => setSearchQuery(e.target.value)}
-                      className="w-full bg-transparent text-[#B8C1BF] placeholder-[#B8C1BF] text-base lg:text-lg font-normal outline-none border-none"
-                    />
-                  </div>
-                  <div className="flex items-center justify-center p-[10px]">
-                    <Search className="w-5 h-5 lg:w-6 lg:h-6 text-[#B8C1BF]" />
-                  </div>
-                </div>
-              </form>
-            </div>
+
 
             <Link to="contact-form" smooth={true} duration={500}>
               <Button

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -64,22 +64,22 @@ const Header = () => {
           </div>
 
           {/* Right Side: Search and Contact */}
-          <div className="hidden md:flex items-center space-x-8">
-            {/* Search Input with Figma Design */}
+          <div className="hidden md:flex items-center space-x-3 lg:space-x-4 xl:space-x-6">
+            {/* Search Input with Figma Design - Responsive widths */}
             <div className="relative">
               <form onSubmit={handleSearch} className="relative">
-                <div className="flex items-center w-[303px] h-[50px] bg-[#03120C] rounded-[32px] shadow-[0_4px_12px_rgba(13,10,44,0.06)]">
-                  <div className="flex-1 px-4">
+                <div className="flex items-center w-[160px] lg:w-[190px] xl:w-[220px] 2xl:w-[240px] h-[50px] bg-[#03120C] rounded-[32px] shadow-[0_4px_12px_rgba(13,10,44,0.06)]">
+                  <div className="flex-1 px-3 lg:px-4">
                     <input
                       type="text"
                       placeholder="Procurar..."
                       value={searchQuery}
                       onChange={(e) => setSearchQuery(e.target.value)}
-                      className="w-full bg-transparent text-[#B8C1BF] placeholder-[#B8C1BF] text-lg font-normal outline-none border-none"
+                      className="w-full bg-transparent text-[#B8C1BF] placeholder-[#B8C1BF] text-base lg:text-lg font-normal outline-none border-none"
                     />
                   </div>
                   <div className="flex items-center justify-center p-[10px]">
-                    <Search className="w-6 h-6 text-[#B8C1BF]" />
+                    <Search className="w-5 h-5 lg:w-6 lg:h-6 text-[#B8C1BF]" />
                   </div>
                 </div>
               </form>
@@ -89,18 +89,18 @@ const Header = () => {
               <Button
                 variant="default"
                 size="sm"
-                className="font-extralight px-6 py-3 rounded-full text-center"
+                className="font-extralight px-4 lg:px-5 xl:px-6 py-3 rounded-full text-center text-sm lg:text-base whitespace-nowrap"
               >
-                {/* Texto para telas grandes (>= 960px) */}
-                <span className="hidden lg:inline">
+                {/* Texto para telas grandes (>= 1280px) */}
+                <span className="hidden xl:inline">
                   Entre em contato
                 </span>
 
-                {/* Texto para telas entre 760px e 959px */}
-                <span className="hidden md:inline lg:hidden">Contato</span>
+                {/* Texto para telas entre 1024px e 1279px */}
+                <span className="hidden lg:inline xl:hidden">Contato</span>
 
-                {/* Texto para telas pequenas (< 760px) */}
-                <span className="inline md:hidden">Contato</span>
+                {/* Texto para telas médias (< 1024px) */}
+                <span className="inline lg:hidden">Contato</span>
               </Button>
             </Link>
           </div>

--- a/src/components/sections/JornadaSection.tsx
+++ b/src/components/sections/JornadaSection.tsx
@@ -59,7 +59,7 @@ const JornadaSection = () => {
           Descubra onde sua empresa está hoje e como pode evoluir para se tornar uma organização verdadeiramente orientada por dados e IA.
         </p>
 
-        <div className="grid grid-cols-1 gap-6 sm:gap-8 md:gap-10 mb-8 sm:mb-12 md:mb-16 md:grid-cols-2 xl:grid-cols-12">
+        <div className="grid grid-cols-1 gap-6 sm:gap-8 md:gap-10 mb-8 sm:mb-12 md:mb-16 md:grid-cols-2 xl:grid-cols-12 justify-items-center md:justify-items-stretch">
           <div className="order-1 md:col-span-1 xl:col-span-4 xl:col-start-1">
             <MaturityCard {...maturityLevels[0]} />
           </div>

--- a/src/components/sections/JornadaSection.tsx
+++ b/src/components/sections/JornadaSection.tsx
@@ -59,20 +59,20 @@ const JornadaSection = () => {
           Descubra onde sua empresa está hoje e como pode evoluir para se tornar uma organização verdadeiramente orientada por dados e IA.
         </p>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 sm:gap-8 md:gap-10 mb-8 sm:mb-12">
-          <div className="order-1">
+        <div className="grid grid-cols-1 gap-6 sm:gap-8 md:gap-10 mb-8 sm:mb-12 md:mb-16 md:grid-cols-2 xl:grid-cols-12">
+          <div className="order-1 md:col-span-1 xl:col-span-4 xl:col-start-1">
             <MaturityCard {...maturityLevels[0]} />
           </div>
-          <div className="order-2">
+          <div className="order-2 md:col-span-1 xl:col-span-4 xl:col-start-5">
             <MaturityCard {...maturityLevels[1]} />
           </div>
-          <div className="order-3">
+          <div className="order-3 md:col-span-2 md:justify-self-center xl:col-span-4 xl:col-start-9 xl:justify-self-start">
             <MaturityCard {...maturityLevels[2]} />
           </div>
-          <div className="order-4 sm:col-start-1 lg:col-start-2">
+          <div className="order-4 md:col-span-1 md:col-start-1 xl:col-span-4 xl:col-start-3 xl:justify-self-center">
             <MaturityCard {...maturityLevels[3]} />
           </div>
-          <div className="order-5 sm:col-start-2 lg:col-start-3">
+          <div className="order-5 md:col-span-1 md:col-start-2 xl:col-span-4 xl:col-start-7 xl:justify-self-center">
             <MaturityCard {...maturityLevels[4]} />
           </div>
         </div>

--- a/src/components/ui/MaturityCard.tsx
+++ b/src/components/ui/MaturityCard.tsx
@@ -6,7 +6,7 @@ interface MaturityCardProps {
 
 const MaturityCard = ({ number, title, description }: MaturityCardProps) => {
   return (
-    <div className="w-full h-full flex-shrink-0 rounded-[10px] border border-[#B8C1BF] bg-[#252525] p-5 sm:p-6 lg:p-7 xl:p-8 flex flex-col min-w-0">
+    <div className="w-full h-full flex-shrink-0 rounded-[10px] border border-[#B8C1BF] bg-[#252525] p-5 sm:p-6 lg:p-7 xl:p-8 flex flex-col min-w-0 max-w-[360px] sm:max-w-[400px] md:max-w-full">
       <div className="flex items-center gap-3 sm:gap-4 mb-5 sm:mb-6">
         <div className="flex-shrink-0 w-10 h-10 sm:w-11 sm:h-11 lg:w-12 lg:h-12 rounded-full bg-[#408E86] flex items-center justify-center">
           <span className="text-[#FAF6E6] font-poppins text-lg sm:text-xl font-extrabold leading-[120%] tracking-[-0.6px]">

--- a/src/components/ui/MaturityCard.tsx
+++ b/src/components/ui/MaturityCard.tsx
@@ -6,18 +6,18 @@ interface MaturityCardProps {
 
 const MaturityCard = ({ number, title, description }: MaturityCardProps) => {
   return (
-    <div className="w-full h-full flex-shrink-0 rounded-[10px] border border-[#B8C1BF] bg-[#252525] p-6 flex flex-col min-w-[280px] sm:min-w-[300px] md:min-w-[340px] lg:min-w-[380px]">
-      <div className="flex items-center gap-4 mb-6">
-        <div className="flex-shrink-0 w-12 h-12 rounded-full bg-[#408E86] flex items-center justify-center">
-          <span className="text-[#FAF6E6] font-poppins text-xl font-extrabold leading-[120%] tracking-[-0.6px]">
+    <div className="w-full h-full flex-shrink-0 rounded-[10px] border border-[#B8C1BF] bg-[#252525] p-5 sm:p-6 lg:p-7 xl:p-8 flex flex-col min-w-0">
+      <div className="flex items-center gap-3 sm:gap-4 mb-5 sm:mb-6">
+        <div className="flex-shrink-0 w-10 h-10 sm:w-11 sm:h-11 lg:w-12 lg:h-12 rounded-full bg-[#408E86] flex items-center justify-center">
+          <span className="text-[#FAF6E6] font-poppins text-lg sm:text-xl font-extrabold leading-[120%] tracking-[-0.6px]">
             {number}
           </span>
         </div>
-        <h3 className="text-white font-poppins text-lg sm:text-xl md:text-2xl font-extrabold leading-[120%] tracking-[-0.72px] flex-1">
+        <h3 className="text-white font-poppins text-base sm:text-lg md:text-xl lg:text-2xl font-extrabold leading-[120%] tracking-[-0.72px] flex-1">
           {title}
         </h3>
       </div>
-      <p className="text-[#B8C1BF] font-poppins text-base sm:text-lg leading-[150%] text-justify flex-1">
+      <p className="text-[#B8C1BF] font-poppins text-sm sm:text-base md:text-lg leading-[150%] text-justify flex-1">
         {description}
       </p>
     </div>


### PR DESCRIPTION
## Purpose

The user identified critical responsiveness issues in the Header and JornadaSection components:

1. **Header Issues**: Between 1214px and 1024px screen widths, the "entre em contato" button text was overflowing its container due to non-responsive search bar and text sizing
2. **JornadaSection Layout**: Needed complete reorganization to follow a specific card arrangement pattern - 3 cards on top row, 2 cards centered below forming an inverted triangle for desktop, with different layouts for various breakpoints

The goal was to implement proper responsive design following the existing design system patterns used in other sections.

## Code Changes

### Header Component (`Header.tsx`)
- **Search Bar Responsiveness**: Implemented responsive widths using Tailwind breakpoints (`w-[160px] lg:w-[190px] xl:w-[220px] 2xl:w-[240px]`)
- **Dynamic Spacing**: Added responsive spacing between elements (`space-x-3 lg:space-x-4 xl:space-x-6`)
- **Text Sizing**: Made search input and button text responsive (`text-base lg:text-lg`)
- **Button Text Breakpoints**: Adjusted text display logic to show "Contato" vs "Entre em contato" at appropriate screen sizes
- **Icon Sizing**: Made search icon responsive (`w-5 h-5 lg:w-6 lg:h-6`)
- **Button Padding**: Implemented responsive padding (`px-4 lg:px-5 xl:px-6`)

### JornadaSection Component (`JornadaSection.tsx`)
- **Grid System Overhaul**: Replaced simple grid with complex 12-column CSS Grid layout for precise positioning
- **Desktop Layout**: Implemented inverted triangle pattern (3 cards top, 2 cards bottom centered)
- **Responsive Breakpoints**: 
  - Mobile: Single column layout
  - Medium (md): 2-column layout with specific card positioning
  - Extra Large (xl): 12-column grid for precise desktop arrangement
- **Card Positioning**: Used `col-span`, `col-start`, and `justify-self` for exact placement

### MaturityCard Component (`MaturityCard.tsx`)
- **Responsive Sizing**: All elements now scale properly across breakpoints
- **Flexible Dimensions**: Replaced fixed `min-w` with responsive sizing and `max-w` constraints
- **Typography Scaling**: Text sizes now adapt from `text-sm` to `text-2xl` based on screen size
- **Spacing Optimization**: Padding and gaps scale responsively (`p-5 sm:p-6 lg:p-7 xl:p-8`)
- **Icon Scaling**: Number badges resize appropriately (`w-10 h-10 sm:w-11 sm:h-11 lg:w-12 lg:h-12`)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 11`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1e4571bd90944ff18a684de5568c4958/pixel-home)

👀 [Preview Link](https://1e4571bd90944ff18a684de5568c4958-pixel-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1e4571bd90944ff18a684de5568c4958</projectId>-->
<!--<branchName>pixel-home</branchName>-->